### PR TITLE
feat: implement multi-sfmt 16-table parallel search

### DIFF
--- a/crates/gen7seed-rainbow/src/domain/missing_format.rs
+++ b/crates/gen7seed-rainbow/src/domain/missing_format.rs
@@ -73,7 +73,7 @@ impl MissingSeedsHeader {
 
     /// Deserialize header from bytes
     pub fn from_bytes(buf: &[u8; FILE_HEADER_SIZE]) -> Result<Self, MissingFormatError> {
-        if &buf[0..8] != &MISSING_MAGIC {
+        if buf[0..8] != MISSING_MAGIC {
             return Err(MissingFormatError::InvalidMagic);
         }
 

--- a/crates/gen7seed-rainbow/src/domain/table_format.rs
+++ b/crates/gen7seed-rainbow/src/domain/table_format.rs
@@ -81,7 +81,7 @@ impl TableHeader {
 
     /// Deserialize header from bytes
     pub fn from_bytes(buf: &[u8; FILE_HEADER_SIZE]) -> Result<Self, TableFormatError> {
-        if &buf[0..8] != &TABLE_MAGIC {
+        if buf[0..8] != TABLE_MAGIC {
             return Err(TableFormatError::InvalidMagic);
         }
 
@@ -205,14 +205,13 @@ pub fn validate_header(
     header: &TableHeader,
     options: &ValidationOptions,
 ) -> Result<(), TableFormatError> {
-    if let Some(expected) = options.expected_consumption {
-        if header.consumption != expected {
+    if let Some(expected) = options.expected_consumption
+        && header.consumption != expected {
             return Err(TableFormatError::ConsumptionMismatch {
                 expected,
                 found: header.consumption,
             });
         }
-    }
 
     if options.require_sorted && !header.is_sorted() {
         return Err(TableFormatError::TableNotSorted);

--- a/crates/gen7seed-rainbow/src/infra/missing_seeds_io.rs
+++ b/crates/gen7seed-rainbow/src/infra/missing_seeds_io.rs
@@ -66,14 +66,13 @@ pub fn load_missing_seeds(
 
     let header = MissingSeedsHeader::from_bytes(&header_buf)?;
 
-    if let Some(expected) = expected_consumption {
-        if header.consumption != expected {
+    if let Some(expected) = expected_consumption
+        && header.consumption != expected {
             return Err(MissingFormatError::ConsumptionMismatch {
                 expected,
                 found: header.consumption,
             });
         }
-    }
 
     let expected_size = expected_missing_file_size(&header);
     if metadata.len() != expected_size {

--- a/crates/gen7seed-rainbow/src/lib.rs
+++ b/crates/gen7seed-rainbow/src/lib.rs
@@ -34,6 +34,10 @@ pub use app::generator::{GenerateOptions, generate_all_tables, generate_table};
 // Re-export searcher function
 pub use app::searcher::{search_seeds, search_seeds_with_validation};
 
+// Re-export 16-table parallel search (multi-sfmt feature)
+#[cfg(feature = "multi-sfmt")]
+pub use app::searcher::search_seeds_x16;
+
 // Re-export coverage analysis types
 pub use app::coverage::{
     BitmapOptions, MissingSeedsResult, build_seed_bitmap, extract_missing_seeds,

--- a/spec/agent/local_014/MULTI_SFMT_SEARCH.md
+++ b/spec/agent/local_014/MULTI_SFMT_SEARCH.md
@@ -1,54 +1,65 @@
 # multi-sfmt を用いた検索高速化 仕様書
 
-> **ステータス: バックログ**
-> 
-> 本仕様は検討段階でバックログ送りとなった。
-> プロファイリング調査の結果、検索処理の98%はチェイン計算（target_hash → end_hash）で占められており、
-> multi-sfmt による16並列化は既存の rayon カラム並列化と重複するため、期待した効果が得られなかった。
-> mini table では約4倍の高速化を確認したが、full table（12.6M エントリ）では約1.04倍に留まった。
-
 ## 1. 概要
 
 ### 1.1 目的
-レインボーテーブル検索処理において、multi-sfmt（16並列SFMT）を活用してチェーン計算を高速化し、検索性能を向上させる。
 
-### 1.2 背景
-- ベンチマーク結果から、multi-sfmt は単体SFMTと比較して約4.1倍高速であることが判明
-  ```
-  chain_generation_2048x2000/single_sfmt: 約160.4–161.6 ms/セット
-  chain_generation_2048x2000/multi_sfmt_x16: 約39.2–39.4 ms/セット
-  → 約4.1倍高速化
-  ```
-- 現行の`searcher.rs`はカラム単位の並列化（rayon）を行っているが、各カラム内のチェーン計算は逐次実行
-- チェーン計算部分にmulti-sfmtを適用することで、さらなる高速化が期待できる
+レインボーテーブル検索処理において、multi-sfmt（16並列SFMT）を活用して**複数テーブルの同時検索**を実現し、検索性能を向上させる。
 
-### 1.3 現状の検索アルゴリズム
+### 1.2 背景・問題
+
+#### 現状
+
+local_016 の改修により、レインボーテーブルは **NUM_TABLES = 16** の複数テーブル構成となった。
+現行の検索処理はテーブルを1枚ずつ逐次検索しており、multi-sfmt の並列性能を活用できていない。
 
 ```
-search_column(consumption, target_hash, column, table):
-    1. target_hash からチェーン終端までハッシュを計算（column → MAX_CHAIN_LENGTH）
-       for n in column..MAX_CHAIN_LENGTH:
-           seed = reduce_hash(h, n)
-           h = gen_hash_from_seed(seed, consumption)  ← ボトルネック
-    2. 終端ハッシュでテーブルを二分探索
-    3. 候補チェーンを検証
-       verify_chain(start_seed, column, target_hash, consumption)  ← ボトルネック
+現行の検索フロー:
+for table_id in 0..16:
+    results = search_seeds(needle, table[table_id], table_id)
+    if results.is_not_empty():
+        return results  # Early exit
 ```
 
-### 1.4 課題
+#### 気づき
 
-| 処理 | 現状 | 問題点 |
-|------|------|--------|
-| Step1（終端計算） | 逐次 `gen_hash_from_seed` × (MAX_CHAIN_LENGTH - column) 回 | 各カラムで独立して計算、並列化されていない |
-| Step3（チェーン検証） | 候補ごとに逐次 `verify_chain` | 複数候補がある場合に非効率 |
+NUM_TABLES = 16 は multi-sfmt の並列度と完全に一致している。
+各テーブルは異なる `table_id` を salt として使用するが、**同一カラム位置**では16テーブル分のハッシュ計算を同時に実行できる。
 
-### 1.5 期待効果
+```
+改修後の検索フロー（同一カラム、16テーブル並列）:
+for column in 0..MAX_CHAIN_LENGTH:
+    # 16テーブル分を同時計算
+    seeds[16] = [reduce_hash_with_salt(h, column, table_id) for table_id in 0..16]
+    hashes[16] = gen_hash_from_seed_x16(seeds, consumption)  ← 16並列SFMT
+```
 
-| 改善箇所 | 期待される効果 |
-|----------|----------------|
-| 終端計算の並列化 | 複数カラムの終端計算を16並列でバッチ処理 |
-| チェーン検証の並列化 | 複数候補のチェーン検証を16並列で実行 |
-| 全体性能 | 約2〜4倍の高速化（カラム並列化との相乗効果） |
+#### 旧仕様との違い
+
+旧仕様（バックログ送り）では単一テーブル内で「階段状並列化」を試みたが、
+rayon によるカラム並列化と重複するため効果が限定的だった。
+新方式は**テーブル軸での並列化**であり、カラム並列化と直交するため相乗効果が期待できる。
+
+### 1.3 期待効果
+
+| 改善箇所 | 現行 | 改修後 |
+|----------|------|--------|
+| テーブル検索 | 逐次（最大16回） | 16並列（1回） |
+| ハッシュ計算 | 単体SFMT | multi-sfmt（約4倍高速） |
+| 早期終了 | 最初の発見で停止 | 全テーブル同時検索 |
+| 全体性能 | 1x | 約4〜6倍（見込み） |
+
+### 1.4 制約事項
+
+| 制約 | 詳細 |
+|------|------|
+| テーブル枚数 | NUM_TABLES は16の倍数である必要がある |
+| feature flag | `multi-sfmt` feature が有効である必要がある |
+| ファイル形式 | シングルファイル形式（`.g7rt`）が必須 |
+
+**注記**: local_019 の改修により、16テーブルは単一の `.g7rt` ファイルに統合された。
+これにより、16テーブルすべてが常に同時にロードされるため、
+「部分ロード」の考慮が不要になった。
 
 ---
 
@@ -56,447 +67,420 @@ search_column(consumption, target_hash, column, table):
 
 | ファイル | 変更種別 | 変更内容 |
 |----------|----------|----------|
-| `crates/gen7seed-rainbow/src/app/searcher.rs` | 修正 | multi-sfmt版検索関数追加 |
-| `crates/gen7seed-rainbow/src/domain/chain.rs` | 修正 | チェーン検証の16並列版追加 |
-| `crates/gen7seed-rainbow/src/domain/hash.rs` | 確認 | 既存の`gen_hash_from_seed_x16`を活用 |
-| `crates/gen7seed-rainbow/benches/table_bench.rs` | 修正 | multi-sfmt版検索のベンチマーク追加 |
+| `crates/gen7seed-rainbow/src/app/searcher.rs` | 修正 | `search_seeds_x16` 公開関数追加、`search_column_x16` 内部関数追加 |
+| `crates/gen7seed-rainbow/src/domain/hash.rs` | 修正 | `MULTI_TABLE_SALTS` 定数、`reduce_hash_x16_multi_table` 内部関数追加 |
+| `crates/gen7seed-rainbow/src/lib.rs` | 修正 | `search_seeds_x16` を公開 |
+| `crates/gen7seed-cli/src/gen7seed_search.rs` | 修正 | `MappedSingleTable` 経由で16テーブル並列検索 |
+| `crates/gen7seed-rainbow/benches/table_bench.rs` | 修正 | multi-sfmt版ベンチマーク追加 |
+
+**注記**: 
+- CODE_SIMPLIFICATION の方針に従い、不要な公開関数のバリエーションは追加しない
+- local_019 のシングルファイル形式対応により、`MappedSingleTable` 経由で16テーブルにアクセス
 
 ---
 
-## 3. アルゴリズム設計
+## 3. 設計方針
 
-### 3.1 「階段状」並列化アプローチ
+### 3.1 アルゴリズム概要
 
-検索処理における還元関数は **カラム位置依存** であるため、異なるカラムでは直接の並列化ができない。
-しかし、以下の「階段状」アプローチにより部分的な並列化が可能。
-
-#### 3.1.1 基本アイデア
+16テーブルを**同一カラム位置で同時に処理**する:
 
 ```
-カラム  0:  H0 → R0 → H1 → R1 → H2 → ... → H2999 → R2999 → H3000
-カラム  1:       H0 → R1 → H1 → R2 → H2 → ... → H2998 → R2999 → H3000
-カラム  2:            H0 → R2 → H1 → R3 → H2 → ... → H2997 → R2999 → H3000
-...
-カラム 15:                 ...                              → H2985 → R2999 → H3000
+search_column_x16(column, target_hash, tables[16], consumption):
+    # Step 1: 16テーブル分の終端ハッシュを同時計算
+    h[16] = [target_hash; 16]
+    for n in column..MAX_CHAIN_LENGTH:
+        seeds[16] = reduce_hash_x16_with_salts(h, n, table_ids)
+        h[16] = gen_hash_from_seed_x16(seeds, consumption)
+
+    # Step 2: 各テーブルで二分探索
+    for table_id in 0..16:
+        candidates = binary_search(tables[table_id], h[table_id])
+        # Step 3: 候補検証（こちらも16並列化可能）
 ```
 
-**観察**: 
-- カラム `n` から始まるチェーンは、還元関数 `R_n, R_{n+1}, ..., R_{2999}` を使用
-- カラム `n` と `n+1` では、最初の1ステップ以外は同じ還元関数列を共有可能
-
-#### 3.1.2 16カラム一括処理
-
-16カラムを1バッチとして処理する場合：
+### 3.2 並列化の構造
 
 ```
-バッチ開始カラム: c (例: c = 0)
-
-Step 0: 各カラム独自の初期ステップ（逐次）
-  カラム c+0:  h0 = target_hash
-  カラム c+1:  h1 = target_hash  
-  ...
-  カラム c+15: h15 = target_hash
-
-Step 1: 最初の還元適用（各カラム異なる還元関数、逐次）
-  カラム c+0:  s0 = reduce(h0, c+0),   h0 = gen_hash(s0)
-  カラム c+1:  s1 = reduce(h1, c+1),   h1 = gen_hash(s1)
-  ...
-  カラム c+15: s15 = reduce(h15, c+15), h15 = gen_hash(s15)
-
-Step 2〜15: 階段状に合流（各カラムで還元関数が異なる、逐次）
-  ...
-
-Step 16以降: 全カラムで還元関数が共通化（multi-sfmt並列化可能）
-  seeds[16] = [s0, s1, ..., s15]
-  for n in (c+16)..MAX_CHAIN_LENGTH:
-      hashes = gen_hash_from_seed_x16(seeds, consumption)  ← 16並列
-      seeds = reduce_hash_x16(hashes, n)                   ← 16並列
+                    ┌─────────────────────────────────────────┐
+                    │           rayon::par_iter               │
+                    │         (カラム単位の並列化)             │
+                    └─────────────────────────────────────────┘
+                                       │
+                    ┌──────────────────┼──────────────────────┐
+                    │                  │                      │
+              column=0           column=1      ...      column=MAX-1
+                    │                  │                      │
+                    ▼                  ▼                      ▼
+          ┌─────────────────────────────────────────────────────────┐
+          │              multi-sfmt (16テーブル並列)                 │
+          │  table_0, table_1, ..., table_15 を同時に処理           │
+          └─────────────────────────────────────────────────────────┘
 ```
 
-### 3.2 合流点までの「階段状」計算
+### 3.3 新規関数シグネチャ
 
-16カラムが共通の還元関数を使えるようになる「合流点」に到達するまでの処理：
+CODE_SIMPLIFICATION で統一された API 設計に従い、シンプルな引数リストを維持する：
 
 ```rust
-/// 16カラムを階段状に処理し、合流点まで進める
-/// 
-/// # Arguments
-/// * `target_hash` - 検索対象のハッシュ値
-/// * `start_column` - 開始カラム（16の倍数）
-/// * `consumption` - 消費乱数数
-/// 
-/// # Returns
-/// 16個のシード値（合流点での状態）
-fn advance_to_confluence(
-    target_hash: u64,
-    start_column: u32,
+/// 16テーブル同時検索（メインAPI）
+///
+/// 既存の search_seeds と同様のシンプルなシグネチャを維持。
+/// table_ids は 0..16 固定のため引数不要。
+#[cfg(feature = "multi-sfmt")]
+pub fn search_seeds_x16(
+    needle_values: [u64; 8],
     consumption: i32,
-) -> [u32; 16] {
-    let mut seeds = [0u32; 16];
-    
-    // 各カラムを個別に合流点まで進める
-    for i in 0..16 {
-        let column = start_column + i as u32;
-        let mut h = target_hash;
-        
-        // column から start_column + 16 まで個別に計算
-        for n in column..(start_column + 16) {
-            let s = reduce_hash(h, n);
-            h = gen_hash_from_seed(s, consumption);
-        }
-        seeds[i] = reduce_hash(h, start_column + 15);
-        // 注: この時点で seeds[i] は column (start_column + 16) で使用するシード
+    tables: [&[ChainEntry]; 16],  // 固定長配列（参照の配列）
+) -> Vec<(u32, u32)>;  // (table_id, seed)
+
+/// 16テーブル分の還元関数（異なるsaltを使用）
+///
+/// 内部関数。table_ids は 0..15 固定のため定数化。
+#[cfg(feature = "multi-sfmt")]
+fn reduce_hash_x16_multi_table(
+    hashes: [u64; 16],
+    column: u32,
+) -> [u32; 16];
+```
+
+**設計方針**:
+- `table_ids` は常に `[0, 1, 2, ..., 15]` なので引数から除外し、定数として内部で保持
+- `gen_hash_from_seed_x16` は既存関数をそのまま使用（salt は reduce 側で適用済み）
+- 参照の配列は `&[&[ChainEntry]; 16]` ではなく `[&[ChainEntry]; 16]` で十分（Copy trait）
+
+---
+
+## 4. 実装仕様
+
+### 4.1 hash.rs: 16テーブル分の還元関数
+
+CODE_SIMPLIFICATION の方針に従い、不要な関数バリエーションは追加しない。
+`table_ids` は定数なので、専用の内部関数として実装する：
+
+```rust
+/// 16テーブル用の salt 定数（コンパイル時計算）
+#[cfg(feature = "multi-sfmt")]
+const MULTI_TABLE_SALTS: [u64; 16] = {
+    let mut salts = [0u64; 16];
+    let mut i = 0;
+    while i < 16 {
+        salts[i] = (i as u64).wrapping_mul(0x9e3779b97f4a7c15);
+        i += 1;
     }
-    
-    seeds
+    salts
+};
+
+/// 16テーブル分のハッシュを還元（内部関数）
+///
+/// 各テーブルで異なる salt (table_id = 0..15) を適用。
+/// salt は定数のため引数不要。
+#[cfg(feature = "multi-sfmt")]
+#[inline]
+fn reduce_hash_x16_multi_table(hashes: [u64; 16], column: u32) -> [u32; 16] {
+    use std::simd::Simd;
+
+    let h = Simd::from_array(hashes);
+    let salts = Simd::from_array(MULTI_TABLE_SALTS);
+    let col = Simd::splat(column as u64);
+    let c1 = Simd::splat(0xbf58476d1ce4e5b9u64);
+    let c2 = Simd::splat(0x94d049bb133111ebu64);
+
+    let mut h = (h ^ salts) + col;
+    h = (h ^ (h >> 30)) * c1;
+    h = (h ^ (h >> 27)) * c2;
+    h ^= h >> 31;
+
+    let arr = h.to_array();
+    std::array::from_fn(|i| arr[i] as u32)
 }
 ```
 
-### 3.3 合流後の並列計算
+**注記**: `gen_hash_from_seed_x16` は既存関数をそのまま使用。
+salt は reduce 側で適用済みなので、ハッシュ計算自体は salt 不要。
 
-合流点以降は16並列で一括処理：
+### 4.2 searcher.rs: 16テーブル同時検索
+
+既存の `search_seeds` と同様のシンプルな設計を維持：
 
 ```rust
-/// 合流点からチェーン終端までを16並列で計算
-/// 
+use crate::constants::MAX_CHAIN_LENGTH;
+use crate::domain::chain::{ChainEntry, verify_chain};
+use crate::domain::hash::{gen_hash, gen_hash_from_seed_x16, reduce_hash_x16_multi_table};
+use rayon::prelude::*;
+use std::collections::HashSet;
+
+/// 16テーブル同時検索（multi-sfmt版）
+///
+/// 既存の `search_seeds` に対応する16テーブル並列版。
+/// table_id は 0..15 固定のため引数不要。
+///
 /// # Arguments
-/// * `seeds` - 16個の合流点シード
-/// * `start_n` - 開始還元関数インデックス
+/// * `needle_values` - 8個の針の値（0-16）
 /// * `consumption` - 消費乱数数
-/// 
+/// * `tables` - 16枚のソート済みテーブルへの参照
+///
 /// # Returns
-/// 16個の終端ハッシュ値
+/// 見つかった (table_id, initial_seed) のペアのリスト
 #[cfg(feature = "multi-sfmt")]
-fn compute_to_end_x16(
-    seeds: [u32; 16],
-    start_n: u32,
+pub fn search_seeds_x16(
+    needle_values: [u64; 8],
     consumption: i32,
-) -> [u64; 16] {
-    let mut current_seeds = seeds;
-    let mut hashes = gen_hash_from_seed_x16(current_seeds, consumption);
-    
-    for n in start_n..MAX_CHAIN_LENGTH {
-        current_seeds = reduce_hash_x16(hashes, n);
-        hashes = gen_hash_from_seed_x16(current_seeds, consumption);
-    }
-    
-    hashes
+    tables: [&[ChainEntry]; 16],
+) -> Vec<(u32, u32)> {
+    let target_hash = gen_hash(needle_values);
+
+    let results: HashSet<(u32, u32)> = (0..MAX_CHAIN_LENGTH)
+        .into_par_iter()
+        .flat_map(|column| search_column_x16(consumption, target_hash, column, &tables))
+        .collect();
+
+    results.into_iter().collect()
 }
-```
 
-### 3.4 検索関数の16並列版
-
-```rust
-/// 16カラムを一括検索
-/// 
-/// # Arguments
-/// * `consumption` - 消費乱数数
-/// * `target_hash` - 検索対象のハッシュ値
-/// * `start_column` - 開始カラム（16の倍数）
-/// * `table` - ソート済みテーブル
-/// 
-/// # Returns
-/// 見つかった初期シードのリスト
+/// 単一カラムで16テーブルを同時検索（内部関数）
 #[cfg(feature = "multi-sfmt")]
-fn search_columns_x16(
+fn search_column_x16(
     consumption: i32,
     target_hash: u64,
-    start_column: u32,
-    table: &[ChainEntry],
-) -> Vec<u32> {
+    column: u32,
+    tables: &[&[ChainEntry]; 16],
+) -> Vec<(u32, u32)> {
     let mut results = Vec::new();
-    
-    // Step 1: 合流点まで階段状に計算
-    let confluence_seeds = advance_to_confluence(target_hash, start_column, consumption);
-    
-    // Step 2: 合流点から終端まで16並列で計算
-    let end_hashes = compute_to_end_x16(confluence_seeds, start_column + 16, consumption);
-    
-    // Step 3: 各カラムの結果でテーブル検索
-    for i in 0..16 {
-        let column = start_column + i as u32;
-        if column >= MAX_CHAIN_LENGTH {
-            continue;
-        }
-        
-        let expected_end_hash = end_hashes[i] as u32;
+
+    // Step 1: 16テーブル分の終端ハッシュを同時計算
+    let mut hashes = [target_hash; 16];
+    for n in column..MAX_CHAIN_LENGTH {
+        let seeds = reduce_hash_x16_multi_table(hashes, n);
+        hashes = gen_hash_from_seed_x16(seeds, consumption);
+    }
+
+    // Step 2: 各テーブルで二分探索＆検証
+    for (table_id, (table, &end_hash)) in tables.iter().zip(hashes.iter()).enumerate() {
+        let expected_end_hash = end_hash as u32;
         let candidates = binary_search_by_end_hash(table, expected_end_hash, consumption);
-        
-        // Step 4: 候補チェーンを検証
+
         for entry in candidates {
-            if let Some(found_seed) = verify_chain(entry.start_seed, column, target_hash, consumption) {
-                results.push(found_seed);
+            if let Some(found_seed) = verify_chain(
+                entry.start_seed,
+                column,
+                target_hash,
+                consumption,
+                table_id as u32,
+            ) {
+                results.push((table_id as u32, found_seed));
             }
         }
     }
-    
+
     results
 }
 ```
 
-### 3.5 全カラム検索の統合
+### 4.3 chain.rs: チェーン検証の16並列化（オプション）
+
+複数候補がある場合の検証を高速化:
 
 ```rust
-/// 全カラムを16並列バッチで検索（rayon並列化と組み合わせ）
-#[cfg(feature = "multi-sfmt")]
-pub fn search_seeds_multi_sfmt(
-    needle_values: [u64; 8],
-    consumption: i32,
-    table: &[ChainEntry],
-) -> Vec<u32> {
-    let target_hash = gen_hash(needle_values);
-    
-    // 16カラムずつのバッチに分割
-    // MAX_CHAIN_LENGTH = 3000 → 188バッチ（3000 / 16 = 187.5）
-    let num_batches = (MAX_CHAIN_LENGTH + 15) / 16;
-    
-    let results: HashSet<u32> = (0..num_batches)
-        .into_par_iter()
-        .flat_map(|batch| {
-            let start_column = batch * 16;
-            search_columns_x16(consumption, target_hash, start_column, table)
-        })
-        .collect();
-    
-    results.into_iter().collect()
-}
-```
-
----
-
-## 4. チェーン検証の16並列化
-
-### 4.1 複数候補の一括検証
-
-テーブル検索で複数の候補が見つかった場合、それらを16並列で検証：
-
-```rust
-/// 最大16個のチェーンを同時検証
-/// 
-/// # Arguments
-/// * `entries` - 検証対象のエントリ（最大16個）
-/// * `column` - チェーン内のカラム位置
-/// * `target_hash` - 検索対象のハッシュ値
-/// * `consumption` - 消費乱数数
-/// 
-/// # Returns
-/// 見つかった初期シードのリスト
+/// 16個のチェーンを同時検証
+///
+/// 同一テーブル・同一カラムで複数候補がある場合に使用
 #[cfg(feature = "multi-sfmt")]
 pub fn verify_chains_x16(
-    entries: &[ChainEntry],
+    start_seeds: [u32; 16],
+    valid_count: usize,
     column: u32,
     target_hash: u64,
     consumption: i32,
+    table_id: u32,
 ) -> Vec<u32> {
-    if entries.is_empty() {
-        return Vec::new();
-    }
-    
-    let count = entries.len().min(16);
-    let mut seeds: [u32; 16] = [0; 16];
-    
-    // 検証対象のstart_seedを収集
-    for (i, entry) in entries.iter().take(count).enumerate() {
-        seeds[i] = entry.start_seed;
-    }
-    
-    // 16並列でチェーンをcolumn位置まで辿る
+    use crate::domain::hash::{gen_hash_from_seed_x16, reduce_hash_x16_with_salt};
+
+    let mut seeds = start_seeds;
+
+    // チェーンをcolumn位置まで辿る
     for n in 0..column {
         let hashes = gen_hash_from_seed_x16(seeds, consumption);
-        seeds = reduce_hash_x16(hashes, n);
+        seeds = reduce_hash_x16_with_salt(hashes, n, table_id);
     }
-    
+
     // column位置でのハッシュを計算して検証
     let hashes = gen_hash_from_seed_x16(seeds, consumption);
-    
+
     let mut results = Vec::new();
-    for i in 0..count {
+    for i in 0..valid_count {
         if hashes[i] == target_hash {
             results.push(seeds[i]);
         }
     }
-    
+
     results
 }
 ```
 
 ---
 
-## 5. 性能見積もり
+## 5. CLI統合
 
-### 5.1 現行実装の計算量
+### 5.1 gen7seed_search.rs の修正
 
-```
-検索1回あたり:
-- カラム検索: MAX_CHAIN_LENGTH × (終端計算 + 二分探索 + 検証)
-- 終端計算: 平均 MAX_CHAIN_LENGTH/2 回の gen_hash_from_seed
-- 合計: O(MAX_CHAIN_LENGTH² × gen_hash_from_seed)
-```
-
-### 5.2 multi-sfmt版の計算量
-
-```
-検索1回あたり:
-- バッチ数: MAX_CHAIN_LENGTH / 16 ≒ 188
-- 各バッチ:
-  - 階段状計算: 16 × 16 / 2 = 128回の逐次 gen_hash_from_seed
-  - 並列計算: (MAX_CHAIN_LENGTH - 16) 回の gen_hash_from_seed_x16
-- 合計: O(MAX_CHAIN_LENGTH² / 16 × gen_hash_from_seed)
-```
-
-### 5.3 高速化率の見積もり
-
-| 項目 | 現行 | multi-sfmt版 | 高速化率 |
-|------|------|--------------|----------|
-| 終端計算 | 逐次 | 16並列（合流後） | 約4倍 |
-| 検証 | 逐次 | 16並列（候補多時） | 約4倍 |
-| 全体 | 1x | 約2〜3x | rayon並列と相乗 |
-
-**注意**: 階段状計算部分のオーバーヘッドがあるため、単純に4倍にはならない。
-
----
-
-## 6. 実装上の考慮事項
-
-### 6.1 エッジケース
-
-| ケース | 対応 |
-|--------|------|
-| MAX_CHAIN_LENGTH が16の倍数でない | 最終バッチで不要なカラムをスキップ |
-| 候補が16未満 | 残りのスロットは無効値で埋め、結果を無視 |
-| 候補が16超 | 複数バッチに分けて処理 |
-
-### 6.2 メモリ配置
+local_019 でシングルファイル形式（`.g7rt`）に移行済み。
+`MappedSingleTable::table(table_id)` で各テーブルにアクセスできる：
 
 ```rust
-// 16並列に適したアライメント
-#[repr(align(64))]
-struct AlignedSeeds([u32; 16]);
-```
+use gen7seed_rainbow::MappedSingleTable;
+use gen7seed_rainbow::search_seeds_x16;
 
-### 6.3 feature flag
-
-```toml
-[features]
-default = ["simd", "multi-sfmt"]
-multi-sfmt = ["simd"]
-simd = []
-```
-
----
-
-## 7. テスト仕様
-
-### 7.1 単体テスト
-
-```rust
+/// 16テーブル同時検索（シングルファイル形式対応）
 #[cfg(feature = "multi-sfmt")]
-#[test]
-fn test_advance_to_confluence() {
-    let target_hash = 12345u64;
-    let consumption = 417;
-    let start_column = 0;
-    
-    let seeds = advance_to_confluence(target_hash, start_column, consumption);
-    
-    // 各カラムの結果を逐次計算と比較
-    for i in 0..16 {
-        let column = start_column + i as u32;
-        let expected = compute_single_column_to_confluence(target_hash, column, consumption);
-        assert_eq!(seeds[i], expected);
+fn search_all_tables_x16(
+    needle_values: [u64; 8],
+    consumption: i32,
+    table: &MappedSingleTable,
+) -> Vec<(u32, u32)> {
+    // MappedSingleTable から16テーブルの参照を取得
+    let tables: [&[ChainEntry]; 16] = std::array::from_fn(|i| {
+        table.table(i as u32).expect("table should exist")
+    });
+
+    search_seeds_x16(needle_values, consumption, tables)
+}
+
+/// 検索統合関数（multi-sfmt 有効時は並列検索、それ以外は逐次検索）
+fn search_all_tables(
+    needle_values: [u64; 8],
+    consumption: i32,
+    table: &MappedSingleTable,
+) -> Vec<(u32, u32)> {
+    #[cfg(feature = "multi-sfmt")]
+    {
+        return search_all_tables_x16(needle_values, consumption, table);
+    }
+
+    #[cfg(not(feature = "multi-sfmt"))]
+    {
+        // 逐次検索（早期終了あり）
+        for table_id in 0..table.num_tables() {
+            if let Some(view) = table.table(table_id) {
+                let results = search_seeds(needle_values, consumption, view, table_id);
+                if !results.is_empty() {
+                    return results.into_iter().map(|seed| (table_id, seed)).collect();
+                }
+            }
+        }
+        Vec::new()
     }
 }
+```
 
-#[cfg(feature = "multi-sfmt")]
-#[test]
-fn test_search_multi_sfmt_matches_sequential() {
-    // テストテーブルを使用
-    let table = generate_test_table(417, 0, 10000);
-    let sorted_table = sort_table(&table, 417);
-    
-    let needle_values = [1u64, 2, 3, 4, 5, 6, 7, 8];
-    
-    let results_seq = search_seeds(needle_values, 417, &sorted_table);
-    let results_multi = search_seeds_multi_sfmt(needle_values, 417, &sorted_table);
-    
-    let set_seq: HashSet<_> = results_seq.into_iter().collect();
-    let set_multi: HashSet<_> = results_multi.into_iter().collect();
-    
-    assert_eq!(set_seq, set_multi);
+### 5.2 現行実装との差異
+
+現行実装（逐次検索）:
+```rust
+for table_id in 0..table_count {
+    let results = search_seeds(needle_values, consumption, view, table_id);
+    if !results.is_empty() {
+        break;  // 早期終了
+    }
 }
 ```
 
-### 7.2 ベンチマーク
+改修後（16並列検索）:
+```rust
+let tables: [&[ChainEntry]; 16] = ...;  // 全テーブル参照
+search_seeds_x16(needle_values, consumption, tables)  // 1回で全検索
+```
+
+### 5.3 戦略選択のトレードオフ
+
+| 方式 | 利点 | 欠点 |
+|------|------|------|
+| 16並列検索 | 全テーブルを1回で検索、multi-sfmt 活用 | 早期終了できない |
+| 逐次検索 | 最初の発見で停止 | 最悪ケースで16回検索 |
+
+実用上、シードが見つかる確率は各テーブルで約 1/16 なので、
+平均的には逐次検索で 8 回程度の検索が必要。
+16並列検索は常に1回なので、平均ケースで約2倍高速。
+
+---
+
+## 6. テスト方針
+
+### 6.1 ユニットテスト
+
+| テスト | 検証内容 |
+|--------|----------|
+| `test_reduce_hash_x16_with_salts` | 各要素が `reduce_hash_with_salt` と一致 |
+| `test_search_column_x16_matches_sequential` | 逐次検索と同一結果 |
+| `test_search_seeds_x16_deterministic` | 同一入力で同一結果 |
+
+### 6.2 統合テスト
+
+| テスト | 検証内容 |
+|--------|----------|
+| `test_roundtrip_x16` | 既知シードから needle 生成→検索→シード発見 |
+| `test_all_tables_covered` | 16テーブルすべてで検索可能 |
+
+### 6.3 ベンチマーク
 
 ```rust
-// benches/table_bench.rs に追加
-
 #[cfg(feature = "multi-sfmt")]
-fn bench_search_multi_sfmt(c: &mut Criterion) {
-    let table = load_sorted_table(417);
-    let needle_values = [5u64, 10, 3, 8, 12, 1, 7, 15];
-    
-    c.bench_function("search_multi_sfmt", |b| {
-        b.iter(|| search_seeds_multi_sfmt(needle_values, 417, &table))
+fn bench_search_x16(c: &mut Criterion) {
+    let tables: [Vec<ChainEntry>; 16] = load_all_tables(417);
+    let table_refs: [&[ChainEntry]; 16] = std::array::from_fn(|i| &tables[i][..]);
+    let needle = generate_needle_from_seed(1000, 417);
+
+    c.bench_function("multi_sfmt_search_x16", |b| {
+        b.iter(|| search_seeds_x16(black_box(needle), 417, &table_refs))
     });
 }
 ```
 
 ---
 
-## 8. 実装計画
+## 7. 実装チェックリスト
 
-### Phase 1: 基礎実装
-1. `advance_to_confluence` 関数の実装
-2. `compute_to_end_x16` 関数の実装
-3. 単体テストの作成
+### Phase 1: コア実装
+- [ ] `hash.rs`: `MULTI_TABLE_SALTS` 定数追加
+- [ ] `hash.rs`: `reduce_hash_x16_multi_table` 内部関数実装
+- [ ] `searcher.rs`: `search_column_x16` 内部関数実装
+- [ ] `searcher.rs`: `search_seeds_x16` 公開関数実装
 
-### Phase 2: 検索統合
-1. `search_columns_x16` 関数の実装
-2. `search_seeds_multi_sfmt` 公開API追加
-3. 既存テストとの整合性確認
+### Phase 2: 公開API
+- [ ] `lib.rs`: `search_seeds_x16` を公開
 
-### Phase 3: 検証並列化
-1. `verify_chains_x16` 関数の実装
-2. 検索関数への統合
+### Phase 3: CLI統合
+- [ ] `gen7seed_search.rs`: `search_all_tables_x16` 関数追加
+- [ ] `gen7seed_search.rs`: `MappedSingleTable::table()` 経由で16テーブル参照取得
+- [ ] `gen7seed_search.rs`: 既存の逐次検索ループを `search_all_tables` に置き換え
 
-### Phase 4: ベンチマーク・最適化
-1. ベンチマーク追加
-2. 性能測定と評価
-3. 必要に応じてパラメータ調整
+### Phase 4: テスト・ベンチマーク
+- [ ] ユニットテスト: `reduce_hash_x16_multi_table` の正当性
+- [ ] ユニットテスト: `search_seeds_x16` と逐次検索の結果一致
+- [ ] ベンチマーク: `search_seeds_x16` vs 逐次検索
 
----
-
-## 9. 代替案の検討
-
-### 9.1 カラム単位での完全並列化（採用せず）
-
-**案**: 各カラムを完全に独立して計算し、rayon並列化のみに依存
-
-**不採用理由**:
-- multi-sfmtの4.1倍高速化を活用できない
-- CPU並列化のみでは限界がある
-
-### 9.2 全カラム事前計算（採用せず）
-
-**案**: 検索前に全カラムの終端ハッシュを事前計算してキャッシュ
-
-**不採用理由**:
-- メモリ使用量が増加（3000 × 8 bytes = 24KB/検索）
-- 検索は通常1回のみなので、キャッシュ効果が薄い
-
-### 9.3 採用案: 階段状並列化
-
-**理由**:
-- multi-sfmtの高速化を最大限活用
-- メモリオーバーヘッドが小さい
-- 既存のrayon並列化と相乗効果
+### Phase 5: オプション（効果測定後に判断）
+- [ ] `chain.rs`: `verify_chains_x16` 実装（候補が多い場合の最適化）
 
 ---
 
-## 10. 参考資料
+## 8. 旧仕様について
+
+本仕様書の旧版（v1）では、単一テーブル内での「階段状並列化」アプローチを提案していた。
+このアプローチは以下の理由でバックログ送りとなった:
+
+- 検索処理の98%はチェイン計算（target_hash → end_hash）で占められている
+- 単一テーブル内での multi-sfmt 並列化は、既存の rayon カラム並列化と重複する
+- mini table では約4倍の高速化を確認したが、full table では約1.04倍に留まった
+
+新方式（v2）では**テーブル軸での並列化**に転換し、カラム並列化との直交性を確保した。
+
+---
+
+## 9. 参考資料
 
 - [local_006/MULTI_SFMT.md](../local_006/MULTI_SFMT.md) - MultipleSFMT仕様
+- [local_016/MULTI_TABLE_PARAMETERS.md](../local_016/MULTI_TABLE_PARAMETERS.md) - 複数テーブル構成
+- [local_019/SINGLE_FILE_TABLE_FORMAT.md](../local_019/SINGLE_FILE_TABLE_FORMAT.md) - シングルファイル形式
 - [local_002/PARALLEL_SEARCH.md](../local_002/PARALLEL_SEARCH.md) - 検索並列化仕様
 - [local_011/REDUCE_HASH_SIMD.md](../local_011/REDUCE_HASH_SIMD.md) - reduce_hash SIMD化
-- [initial/SFMT_RAINBOW_SPEC.md](../../initial/SFMT_RAINBOW_SPEC.md) - レインボーテーブル全体仕様


### PR DESCRIPTION
## 概要

multi-sfmt を活用した16テーブル同時検索機能を実装。

## 変更内容

### コア実装
- `hash.rs`: `MULTI_TABLE_SALTS` 定数と `reduce_hash_x16_multi_table` 関数を追加
- `searcher.rs`: `search_seeds_x16` (公開) と `search_column_x16` (内部) を追加
- `lib.rs`: `search_seeds_x16` を re-export

### CLI統合
- `gen7seed_search.rs`: multi-sfmt 有効時に並列検索を使用

### テスト・ベンチマーク
- `table_validation.rs`: x16検索の統合テスト追加（full table 必要）
- `table_bench.rs`: `bench_search_x16` ベンチマーク追加

### ドキュメント
- `spec/agent/local_014/MULTI_SFMT_SEARCH.md`: 仕様書を更新

## 技術詳細

- 16テーブルを同時に検索する `search_seeds_x16` 関数
- `MULTI_TABLE_SALTS` を使って各テーブルに異なる salt を適用
- rayon によるカラム並列 + multi-sfmt による16テーブル同時ハッシュ計算

## テスト結果

- ✅ ユニットテスト 122件パス
- ✅ clippy 警告ゼロ
- ✅ cargo fmt 適用済み

Closes #14